### PR TITLE
Merge development to main 20240806_171846

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,6 +13,13 @@ Use the following lines to install casual-isearch-tmenu.
   (keymap-set isearch-mode-map "<f2>" #'casual-isearch-tmenu)
 #+end_src
 
+Alternately install with ~use-package~ using the following initialization:
+#+begin_src elisp :lexical no
+  (use-package casual-isearch
+    :ensure t
+    :bind (:map isearch-mode-map ("C-o" . casual-isearch-tmenu)))
+#+end_src
+
 The keybinding to ~casual-isearch-tmenu~ can be changed to user preference.
 
 * Menu Commands

--- a/casual-isearch.el
+++ b/casual-isearch.el
@@ -36,7 +36,12 @@
 ;; `casual-isearch-tmenu'.  Tune the keybinding to your taste.
 
 ;; (require 'casual-isearch)
-;; (keymap-set isearch-mode-map "<f2>" #'casual-isearch-tmenu)
+;; (keymap-set isearch-mode-map "C-o" #'casual-isearch-tmenu)
+
+;; Alternately with `use-package':
+;; (use-package casual-isearch
+;;   :ensure t
+;;   :bind (:map isearch-mode-map ("C-o" . casual-isearch-tmenu)))
 
 ;;; Code:
 

--- a/casual-isearch.el
+++ b/casual-isearch.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-isearch
 ;; Keywords: wp
-;; Version: 1.8.1
+;; Version: 1.8.2
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Change default binding to C-o to be consistent with Casual**
  This documentation change recommends using the binding "C-o" rather than "<f2>" to
  invoke casual-isearch-tmenu. This binding makes it consistent with other Casual
  packages that use "C-o" to invoke a mode-specific Transient.
  

- **Bump version to 1.8.2**
  