### PR TITLE
Merge development to main 20240930_222500

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ create-release-tag: checkout-main bump
 
 create-gh-release: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
 create-gh-release: create-release-tag
-	gh release create -t v$(VERSION_BUMP) --generate-notes
+	gh release create -t v$(VERSION_BUMP) --generate-notes $(VERSION_BUMP)
 
 status:
 	git status

--- a/lisp/casual-isearch-version.el
+++ b/lisp/casual-isearch-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-isearch-version "1.10.0"
+(defconst casual-isearch-version "1.10.1-rc.1"
   "Casual I-Search Version.")
 
 (defun casual-isearch-version ()

--- a/lisp/casual-isearch.el
+++ b/lisp/casual-isearch.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-isearch
 ;; Keywords: wp
-;; Version: 1.10.0
+;; Version: 1.10.1-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Sync `Version:` commit with release tag for package build**
  This changes the build process to sync the package `Version:` field commit
  with the release tag. This is to support use-package :vc in the upcoming Emacs
  30 release.
  

- **Bump version to 1.10.1-rc.1**
  